### PR TITLE
skip azure workspaces due to permissions error in getAllDataTables() function

### DIFF
--- a/R/collectAllMeta.R
+++ b/R/collectAllMeta.R
@@ -126,7 +126,9 @@ getAllDataTables <- function(workspaces = NULL) {
     colnames(allCombined) <- dt_colnames
     
     for (i in seq_len(nrow(workspaces))) {
-        
+
+      tryCatch({
+        # Try to process the workspace        
         namespace <- workspaces$namespace[i]
         name <- workspaces$name[i]
         workspaceId <- workspaces$workspaceId[i]
@@ -136,6 +138,10 @@ getAllDataTables <- function(workspaces = NULL) {
         res$namespace <- namespace
         res$name <- name
         allCombined <- plyr::rbind.fill(allCombined, res)
+      }, error = function(e) {
+        # If an error occurs, skip that workspace
+        message("Skipping workspace ", i, " due to error: ", e$message)
+      })
     }
     
     return(allCombined)


### PR DESCRIPTION
The avtables() function in the Terra R package is unable to access necessary data from AZURE workspaces and gives the following error message:
_'avtables' failed: Internal Server Error (HTTP 500). This API is disabled for AZURE workspaces._
I have modified the getAllDataTables() function to skip workspaces which are inaccessible due to errors like this.